### PR TITLE
Support full names

### DIFF
--- a/lib/beygla.spec.ts
+++ b/lib/beygla.spec.ts
@@ -68,4 +68,52 @@ describe("applyCase", () => {
       expect(out).toEqual(expected);
     }
   });
+
+  it("applies a case to a full name", () => {
+    const sourceName = "Gunnar Sigurberg Brjánsson";
+
+    const out = applyCase("þgf", sourceName);
+
+    expect(out).toEqual("Gunnari Sigurbergi Brjánssyni");
+  });
+
+  it("strips whitespace in full names", () => {
+    const sourceName = "  \n  Hildigerður  Oddný\tPatreksdóttir  \n\n";
+
+    const out = applyCase("þf", sourceName);
+
+    expect(out).toEqual("Hildigerði Oddnýju Patreksdóttur");
+  });
+
+  it("applies a case to a first and middle name", () => {
+    const sourceName = "Þorleifur Sigþór";
+
+    const out = applyCase("ef", sourceName);
+
+    expect(out).toEqual("Þorleifs Sigþórs");
+  });
+
+  it("applies a case only the last name", () => {
+    const sourceName = "Ríkharðsdóttir";
+
+    const out = applyCase("ef", sourceName);
+
+    expect(out).toEqual("Ríkharðsdóttur");
+  });
+
+  it("applies a case to the first and last name", () => {
+    const sourceName = "Magnús Herleifsson";
+
+    const out = applyCase("þgf", sourceName);
+
+    expect(out).toEqual("Magnúsi Herleifssyni");
+  });
+
+  it("applies a case to only 'son' or 'dóttir'", () => {
+    const son = applyCase("þgf", "son");
+    const dottir = applyCase("þgf", "dóttir");
+
+    expect(son).toEqual("syni");
+    expect(dottir).toEqual("dóttur");
+  });
 });

--- a/lib/beygla.ts
+++ b/lib/beygla.ts
@@ -67,11 +67,6 @@ function applyCaseToName(caseStr: Case, name: string) {
   return name;
 }
 
-function applyCaseToString(caseStr: Case, name: string) {
-  const names = name.split(/\s+/).filter(Boolean);
-  return names.map((name) => applyCaseToName(caseStr, name)).join(" ");
-}
-
 /**
  * Applies a case to a source name provided in the nominative
  * case (nefnifall).
@@ -99,5 +94,6 @@ function applyCaseToString(caseStr: Case, name: string) {
  * @param caseStr - The case to apply to the name to, e.g. `þf`
  */
 export function applyCase(caseStr: Case, name: string): string {
-  return applyCaseToString(caseStr, name);
+  const names = name.split(/\s+/).filter(Boolean);
+  return names.map((name) => applyCaseToName(caseStr, name)).join(" ");
 }

--- a/lib/beygla.ts
+++ b/lib/beygla.ts
@@ -42,29 +42,62 @@ function declineName(name: string, declension: string, caseStr: Case): string {
   return root + appendices[caseIndex];
 }
 
+const namesThatEndWithSon = ["Samson", "Jason"];
+
+function applyCaseToName(caseStr: Case, name: string) {
+  let postfix: [string, string] | null = null;
+
+  for (const [ending, declension] of [
+    ["son", "2;on,on,yni,onar"],
+    ["dóttir", "2;ir,ur,ur,ur"],
+  ]) {
+    if (!name.endsWith(ending)) continue;
+    if (namesThatEndWithSon.indexOf(name) !== -1) continue;
+    postfix = [ending, declension];
+    name = name.split(ending)[0];
+  }
+
+  if (!postfix) {
+    const declension = extractDeclension(trie, name);
+    if (declension) name = declineName(name, declension, caseStr);
+  } else {
+    name += declineName(postfix[0], postfix[1], caseStr);
+  }
+
+  return name;
+}
+
+function applyCaseToString(caseStr: Case, name: string) {
+  const names = name.split(/\s+/).filter(Boolean);
+  return names.map((name) => applyCaseToName(caseStr, name)).join(" ");
+}
+
 /**
- * This function can applies one of the following cases to a source name
- * provided in the nominative case (nefnifall).
+ * Applies a case to a source name provided in the nominative
+ * case (nefnifall).
+ *
+ * @example
+ * ```tsx
+ * applyCase("ef", "Jóhann");
+ * //=> "Jóhannesar"
+ *
+ * applyCase("þgf", "Helga Fríða Smáradóttir");
+ * //=> "Helgu Fríðu Smáradóttur"
+ * ```
+ *
+ * The name provided must be an Icelandic name in the nominative case
+ * (nefnifall). Otherwise, an unexpected output is likely.
+ *
+ * The supported cases are:
  *
  * - Nominative `nom` (nefnifall `nf` in Icelandic)
  * - Accusative `acc` (þolfall `þf` in Icelandic)
  * - Dative `dat` (þágufall `þgf` in Icelandic)
  * - Genitive `gen` (eignarfall `ef` in Icelandic)
  *
- * @example
- * ```tsx
- * applyCase("ef", "Jóhann");
- * //=> "Jóhannesar"
- * ```
- *
- * The name provided must be an Icelandic name in the nominative case
- * (nefnifall) or an unexpected output is likely.
- *
  * @param name - An Icelandic name in the nominative case (nefnifall)
  * @param caseStr - The case to apply to the name to, e.g. `þf`
  */
 export function applyCase(caseStr: Case, name: string): string {
-  const declension = extractDeclension(trie, name);
-  if (!declension) return name;
-  return declineName(name, declension, caseStr);
+  return applyCaseToString(caseStr, name);
 }

--- a/lib/beygla.ts
+++ b/lib/beygla.ts
@@ -90,6 +90,14 @@ function applyCaseToName(caseStr: Case, name: string) {
  * - Dative `dat` (þágufall `þgf` in Icelandic)
  * - Genitive `gen` (eignarfall `ef` in Icelandic)
  *
+ * Note that superfluous whitespace is not retained:
+ *
+ * @example
+ * ```tsx
+ * applyCase("þf", "  \n  Hildigerður  Oddný\tPatreksdóttir  \n\n");
+ * //=> "Hildigerði Oddnýju Patreksdóttur"
+ * ```
+ *
  * @param name - An Icelandic name in the nominative case (nefnifall)
  * @param caseStr - The case to apply to the name to, e.g. `þf`
  */


### PR DESCRIPTION
Currently, `beygla` just support single names:

```tsx
applyCase("ef", "Jóhann");
//=> "Jóhannesar"
```

In this PR, support for full names is added:

```tsx
applyCase("þgf", "Helga Fríða Smáradóttir");
//=> "Helgu Fríðu Smáradóttur"
```

Note that superfluous whitespace is not retained:

```tsx
applyCase("þf", "  \n  Hildigerður  Oddný\tPatreksdóttir  \n\n");
//=> "Hildigerði Oddnýju Patreksdóttur"
```