### PR TITLE
Excluded names

### DIFF
--- a/scripts/group-names.ts
+++ b/scripts/group-names.ts
@@ -70,8 +70,28 @@ async function main() {
     out.push([nf.name, þf.name, þgf.name, ef.name]);
   }
 
-  const filePath = path.resolve(__dirname, "../out/grouped-names.json");
-  writeAndLogSize(filePath, JSON.stringify(out, null, 2));
+  const excludedNames = [...nameSet].filter((name) => !groups[name]);
+
+  const ratio = excludedNames.length / names.length;
+  const percentage = (ratio * 100).toFixed(2) + "%";
+
+  console.log(
+    `${excludedNames.length} of ${names.length} names (${percentage}) in 'name-cases.csv' are not present in 'words.csv' and are not included.\n`
+  );
+
+  const groupedNamesfilePath = path.resolve(
+    __dirname,
+    "../out/grouped-names.json"
+  );
+  const excludedNamesfilePath = path.resolve(
+    __dirname,
+    "../out/excluded-names.json"
+  );
+  writeAndLogSize(groupedNamesfilePath, JSON.stringify(out, null, 2));
+  writeAndLogSize(
+    excludedNamesfilePath,
+    JSON.stringify(excludedNames, null, 2)
+  );
 }
 
 main();


### PR DESCRIPTION
A number of names are legal Icelandic names, but their cases are not present in `word-cases.csv`.

These are now documented in the `group-names` script:

```
Running 'group-names'

858 of 4505 names (19.05%) in 'name-cases.csv' are not present in 'words.csv' and are excluded.

Created file 'grouped-names.json'
        Size:           254.22 kB
        Gzip size:      30.53 kB (12.01%)
Created file 'excluded-names.json'
        Size:           10.8 kB
        Gzip size:      3.78 kB (34.96%)

Ran script 'group-names' in 880ms
```

The thing that's surprising to me is that Árnastofnun does not have the cases for 19% of legal Icelandic names yet.
