### PR TITLE
Consider word categories

### DIFF
--- a/lib/beygla.spec.ts
+++ b/lib/beygla.spec.ts
@@ -76,7 +76,7 @@ describe("applyCase", () => {
 
     const out = applyCase("þgf", sourceName);
 
-    expect(out).toEqual("Gunnari Sigurbergi Brjánssyni");
+    expect(out).toEqual("Gunnari Sigurberg Brjánssyni");
   });
 
   it("strips whitespace in full names", () => {
@@ -150,12 +150,13 @@ describe("applyCase", () => {
       ["Sófús", "0;,,i,ar"],
       ["Kristólín", "0;,,,ar"],
       ["Jasper", "0;,,,s"],
-      ["Rúnel", "0;,,i,s"],
-      ["Agok", "0;,,i,s"],
+      ["Agok", "0;,,,s"],
     ];
 
     for (const [name, declension] of tests) {
-      expect(getDeclensionForName(name)).toEqual(declension);
+      expect(`${name}: ${getDeclensionForName(name)}`).toEqual(
+        `${name}: ${declension}`
+      );
     }
   });
 
@@ -170,7 +171,9 @@ describe("applyCase", () => {
     ];
 
     for (const name of tests) {
-      expect(getDeclensionForName(name)).toEqual(null);
+      expect(`${name}: ${getDeclensionForName(name)}`).toEqual(
+        `${name}: ${null}`
+      );
     }
   });
 });

--- a/lib/beygla.spec.ts
+++ b/lib/beygla.spec.ts
@@ -176,4 +176,17 @@ describe("applyCase", () => {
       );
     }
   });
+
+  test("it uses the declensions for the person, not the company/organization", () => {
+    const tests = [
+      ["nf", "Eldey"],
+      ["þf", "Eldeyju"],
+      ["þgf", "Eldeyju"],
+      ["ef", "Eldeyjar"],
+    ] as const;
+
+    for (const [_case, name] of tests) {
+      expect(applyCase(_case, "Eldey")).toEqual(name);
+    }
+  });
 });

--- a/lib/compress/types.ts
+++ b/lib/compress/types.ts
@@ -5,14 +5,37 @@ export enum Case {
   Dative = 4,
 }
 
+// See https://bin.arnastofnun.is/gogn/k-snid
+export enum WordCategory {
+  PersonNames = "ism",
+  NonIcelandicPersonNames = "erm",
+  MythicalName = "hetja",
+  PlaceNames = "örn",
+  Nicknames = "gæl",
+  FamilyNames = "ætt",
+  GeographicalNames = "bær",
+  NonIcelandicGeographicalNames = "erl",
+  CountryNames = "lönd",
+  CategoriesOfPeoples = "ffl",
+  StreetNames = "göt",
+  CompanyOrOrganizationName = "fyr",
+  OtherNames = "heö",
+  AstrologicalNames = "stja",
+  General = "alm",
+}
+
 export interface DeclinedName {
   base: string;
   name: string;
   case: Case;
+  gender: string;
+  category: WordCategory;
 }
 
 export interface UnprocessedName {
   base: string;
   name: string;
   case: string;
+  gender: string;
+  category: WordCategory;
 }

--- a/lib/preprocess/format/case.ts
+++ b/lib/preprocess/format/case.ts
@@ -1,22 +1,25 @@
 import { Case } from "../../compress/types";
 
+export function isFirstVariationOfCase(caseString: string): boolean {
+  switch (caseString) {
+    case "NFET":
+    case "ÞFET":
+    case "ÞGFET":
+    case "EFET":
+      return true;
+  }
+  return false;
+}
+
 export function getCase(caseString: string): Case {
   switch (caseString) {
     case "NFET":
       return Case.Nominative;
     case "ÞFET":
-    case "ÞFET2":
-    case "ÞFET3":
-      /** @todo only use one of these, not both */
       return Case.Accusative;
     case "ÞGFET":
-    case "ÞGFET2":
-    case "ÞGFET3":
-      /** @todo only use one of these, not both */
       return Case.Dative;
     case "EFET":
-    case "EFET2":
-      /** @todo only use one of these, not both */
       return Case.Genitive;
     default:
       throw new Error(`Unexpected case '${caseString}'`);

--- a/lib/preprocess/format/name.ts
+++ b/lib/preprocess/format/name.ts
@@ -1,13 +1,34 @@
-import { DeclinedName, UnprocessedName } from "../../compress/types";
+import {
+  DeclinedName,
+  UnprocessedName,
+  WordCategory,
+} from "../../compress/types";
 import { getCase } from "./case";
 
 export function getRawName(line: string): UnprocessedName {
-  const [base, _id, _gender, name, caseString] = line.split(";");
+  // Properties prefixed with '_bin' have not been translated.
+  //
+  // See https://bin.arnastofnun.is/gogn/k-snid
+  const [
+    base,
+    _id,
+    gender,
+    category,
+    _bin_einkunn,
+    _bin_malsnid_ords,
+    _bin_malfraedi,
+    _bin_millivisun,
+    _bin_birting,
+    name,
+    caseString,
+  ] = line.split(";");
 
   return {
     base,
     case: caseString,
     name,
+    category: category as WordCategory,
+    gender,
   };
 }
 
@@ -18,5 +39,7 @@ export function formatName(name: UnprocessedName): DeclinedName {
     base: name.base,
     name: name.name,
     case: nameCase,
+    category: name.category,
+    gender: name.gender,
   };
 }

--- a/scripts/download-words.ts
+++ b/scripts/download-words.ts
@@ -9,7 +9,7 @@ const csvFilePath = path.resolve(__dirname, "../data/word-cases.csv");
 console.log(`Downloading file\n`);
 
 execSync(
-  `curl -o ${zipFilePath} https://bin.arnastofnun.is/django/api/nidurhal/?file=Storasnid_beygm.csv.zip`,
+  `curl -o ${zipFilePath} https://bin.arnastofnun.is/django/api/nidurhal/?file=KRISTINsnid.csv.zip`,
   { stdio: "inherit" }
 );
 
@@ -25,8 +25,8 @@ const unzip = async () => {
         return;
       }
       zipfile.on("entry", (entry) => {
-        if (entry.fileName === "Storasnid_beygm.csv.sha256sum") return;
-        if (entry.fileName === "Storasnid_beygm.csv") {
+        if (entry.fileName === "KRISTINsnid.csv.sha256sum") return;
+        if (entry.fileName === "KRISTINsnid.csv") {
           zipfile.openReadStream(entry, (err, readStream) => {
             if (err) {
               reject(err);

--- a/scripts/filter-names.ts
+++ b/scripts/filter-names.ts
@@ -7,6 +7,8 @@ import fsSync from "fs";
 import path from "path";
 import { getNames } from "../lib/preprocess/data/getNames";
 import { logWriteAndSize } from "../lib/preprocess/utils/gzip";
+import { getRawName } from "../lib/preprocess/format/name";
+import { isFirstVariationOfCase } from "../lib/preprocess/format/case";
 
 const nameCasesCsvFilePath = path.resolve(__dirname, "../out/name-cases.csv");
 const wordCasesCsvFilePath = path.resolve(__dirname, "../data/word-cases.csv");
@@ -25,9 +27,11 @@ async function main() {
   for await (const line of inputFile.readLines()) {
     nInputLines++;
 
-    const name = line.split(";")[0];
-
-    if (!nameSet.has(name)) {
+    const name = getRawName(line);
+    if (!nameSet.has(name.base)) {
+      continue;
+    }
+    if (!isFirstVariationOfCase(name.case)) {
       continue;
     }
 
@@ -37,7 +41,7 @@ async function main() {
 
   console.log(`Filtered ${nInputLines} entries into ${nOutputLines} entries.`);
 
-  await logWriteAndSize(nameCasesCsvFilePath);
+  logWriteAndSize(nameCasesCsvFilePath);
 }
 
 main();

--- a/scripts/group-names.ts
+++ b/scripts/group-names.ts
@@ -143,7 +143,7 @@ async function main() {
 
     let gender: string;
     const genders = Object.keys(byGender);
-    assert(genders.length > 0, "should have at least 1 genders");
+    assert(genders.length > 0, "should have at least 1 gender");
     if (genders.length > 1) {
       namesWithMultipleGenders.add(names[0].base);
       continue;

--- a/scripts/group-names.ts
+++ b/scripts/group-names.ts
@@ -76,7 +76,6 @@ async function main() {
   const out: string[][] = [];
 
   const namesWithMultipleGenders = new Set();
-  const namesWithMultipleDeclensions = new Set();
 
   for (const names of Object.values(groups)) {
     const byCategory: {
@@ -107,9 +106,6 @@ async function main() {
       }
       byCategory[name.category] ||= {};
       byCategory[name.category][name.gender] ||= {};
-      if (byCategory[name.category][name.gender][_case]) {
-        namesWithMultipleDeclensions.add(name.base);
-      }
       byCategory[name.category][name.gender][_case] ||= name;
     }
 
@@ -174,9 +170,6 @@ async function main() {
     `${excludedNames.length} of ${names.length} names (${percentage}) in 'name-cases.csv' are not present in 'words.csv' and are not included.\n`
   );
 
-  console.log(
-    `Found ${namesWithMultipleDeclensions.size} names with multiple declensions. The last declension is used.`
-  );
   console.log(
     `Found ${namesWithMultipleGenders.size} names with multiple genders. They are omitted from Beygla.\n`
   );

--- a/scripts/group-names.ts
+++ b/scripts/group-names.ts
@@ -4,10 +4,47 @@ import { getNames } from "../lib/preprocess/data/getNames";
 import { isDefiniteArticle } from "../lib/preprocess/format/article";
 import { isCasePlural } from "../lib/preprocess/format/case";
 import { formatName, getRawName } from "../lib/preprocess/format/name";
-import { Case, DeclinedName } from "../lib/compress/types";
+import { Case, DeclinedName, WordCategory } from "../lib/compress/types";
 import { writeAndLogSize } from "../lib/preprocess/utils/gzip";
+import assert from "assert";
 
 const nameCasesFilePath = path.resolve(__dirname, "../out/name-cases.csv");
+
+// Some names (e.g. Eldey) can both be a personal name (eigin nafn) and the name
+// of a company/organization (stofnunar- eða fyrirtækisheiti).
+//
+// These are not always declined in the same manner. See the following explainer
+// from BÍN for an example:
+//
+//    https://bin.arnastofnun.is/korn/7
+//
+// There's LOTS of word categories, with various degrees of overlap. All of the
+// following categories contain at least one legal Icelandic name.
+//
+// The following list specifies the "category preference order". If a name
+// exists in multiple categories, the first category in the list will be picked.
+//
+// PS: Aside from the first few elements, this ordering is mostly arbitrary. If
+//     reasons for preferring one category over another is discovered, then this
+//     list can be amended.
+//
+const categoriesInOrderOfPreference = [
+  WordCategory.PersonNames,
+  WordCategory.NonIcelandicPersonNames,
+  WordCategory.Nicknames,
+  WordCategory.MythicalName,
+  WordCategory.FamilyNames,
+  WordCategory.GeographicalNames,
+  WordCategory.PlaceNames,
+  WordCategory.AstrologicalNames,
+  WordCategory.OtherNames,
+  WordCategory.NonIcelandicGeographicalNames,
+  WordCategory.CountryNames,
+  WordCategory.StreetNames,
+  WordCategory.CategoriesOfPeoples,
+  WordCategory.CompanyOrOrganizationName,
+  WordCategory.General,
+] as string[];
 
 async function main() {
   const fileContent = await fs.readFile(nameCasesFilePath, "utf-8");
@@ -38,33 +75,91 @@ async function main() {
 
   const out: string[][] = [];
 
+  const namesWithMultipleGenders = new Set();
+  const namesWithMultipleDeclensions = new Set();
+
   for (const names of Object.values(groups)) {
-    let nf: DeclinedName | undefined;
-    let þf: DeclinedName | undefined;
-    let þgf: DeclinedName | undefined;
-    let ef: DeclinedName | undefined;
+    const byCategory: {
+      [category: string]: {
+        [gender: string]: {
+          [_case: string]: DeclinedName;
+        };
+      };
+    } = {};
 
     for (const name of names) {
+      let _case;
       switch (name.case) {
         case Case.Nominative:
-          nf = name;
+          _case = "nf";
           break;
         case Case.Accusative:
-          þf = name;
+          _case = "þf";
           break;
         case Case.Dative:
-          þgf = name;
+          _case = "þgf";
           break;
         case Case.Genitive:
-          ef = name;
+          _case = "ef";
           break;
         default:
           throw new Error(`Unexpected case '${name.case}'`);
       }
+      byCategory[name.category] ||= {};
+      byCategory[name.category][name.gender] ||= {};
+      if (byCategory[name.category][name.gender][_case]) {
+        namesWithMultipleDeclensions.add(name.base);
+      }
+      byCategory[name.category][name.gender][_case] ||= name;
     }
 
+    let category: string | undefined;
+    const categories = Object.keys(byCategory);
+
+    assert(categories.length > 0, "should have at least 1 category");
+
+    if (
+      categories.length === 1 &&
+      ["gæl,ism", "dýr,hetja"].includes(categories[0])
+    ) {
+      // This seems like a data entry error, for which BÍN should be contacted.
+      // These occur for 1 word each.
+      //
+      // Anyway, ignore these while they are sorted out in the source.
+      continue;
+    }
+
+    for (const preferredCategory of categoriesInOrderOfPreference) {
+      if (categories.includes(preferredCategory)) {
+        category = preferredCategory;
+        break;
+      }
+    }
+    if (!category) {
+      throw new Error(
+        `No preferred category matched in list [${categories.join(
+          ", "
+        )}] for name '${names[0].base}'`
+      );
+    }
+
+    const byGender = byCategory[category];
+
+    let gender: string;
+    const genders = Object.keys(byGender);
+    assert(genders.length > 0, "should have at least 1 genders");
+    if (genders.length > 1) {
+      namesWithMultipleGenders.add(names[0].base);
+      continue;
+    } else {
+      gender = genders[0];
+    }
+
+    const byCase = byGender[gender];
+    const { nf, þf, þgf, ef } = byCase;
+
     if (!nf || !þf || !þgf || !ef) {
-      throw new Error(`Missing case for name '${names![0].base}'`);
+      throw new Error(`Missing case for name '${names[0].base}'`);
     }
 
     out.push([nf.name, þf.name, þgf.name, ef.name]);
@@ -77,6 +172,13 @@ async function main() {
 
   console.log(
     `${excludedNames.length} of ${names.length} names (${percentage}) in 'name-cases.csv' are not present in 'words.csv' and are not included.\n`
+  );
+
+  console.log(
+    `Found ${namesWithMultipleDeclensions.size} names with multiple declensions. The last declension is used.`
+  );
+  console.log(
+    `Found ${namesWithMultipleGenders.size} names with multiple genders. They are omitted from Beygla.\n`
   );
 
   const groupedNamesfilePath = path.resolve(


### PR DESCRIPTION
Closes #11

# What

As pointed out in #11, some legal Icelandic names have multiple potential declensions. For example, the word Eldey exists as:

 * Eldey - female name
 * Eldey - name of company/organization

BÍN has published an explainer for why this is: https://bin.arnastofnun.is/korn/7

To distinguish these, BÍN uses "word categories" (called _Hluti BÍN_ in Icelandic):

> Hluti BÍN er merkingarleg flokkun orðaforðans.

There are loads of categories (47, to be exact). Here are some examples:

 * `ism` - Personal Names
 * `erm` - Non-Icelandic Personal Names
 * `gæl` - Nicknames
 * `íþr` - Sports
 * `stja` - Astrological names

The issue described in #11 occurs when the same name (e.g. Eldey) exists in multiple word categories AND the non-personal name category is picked because it appears later in the dataset.


# How

## Download data including word categories

The data we are currently using ([Storasnid_beygm][Storasnid_beygm]) does not contain these categories. However, they are present in [KRISTINsnid][KRISTINsnid].

[Storasnid_beygm]: https://bin.arnastofnun.is/django/api/nidurhal/?file=Storasnid_beygm.csv.zip
[KRISTINsnid]: https://bin.arnastofnun.is/django/api/nidurhal/?file=KRISTINsnid.csv.zip

Updated the `download-names` script to download `KRISTINsnid` instead of `Storasnid_beygm`. This required updating `getRawName` because KRISTINsnid contains way more columns:

```
# Storasnid_beygm
Eldey;361357;kvk;Eldey;NFET;1;;

# KRISTINsnid
Eldey;361357;kvk;ism;1;;;;V;Eldey;NFET;1;;;
```


## Prefer certain word categories

It turns out that not all legal Icelandic names exist under the `ism` category.

When a word exists in multiple categories, we pick the category according to the "category preference order":

```tsx
const categoriesInOrderOfPreference = [
  WordCategory.PersonNames,
  WordCategory.NonIcelandicPersonNames,
  WordCategory.Nicknames,
  WordCategory.MythicalName,
  WordCategory.FamilyNames,
  WordCategory.GeographicalNames,
  WordCategory.PlaceNames,
  WordCategory.AstrologicalNames,
  WordCategory.OtherNames,
  WordCategory.NonIcelandicGeographicalNames,
  WordCategory.CountryNames,
  WordCategory.StreetNames,
  WordCategory.CategoriesOfPeoples,
  WordCategory.CompanyOrOrganizationName,
  WordCategory.General,
];
```

Using this category preference order, these are the legal Icelandic names by category:

| Category | Preferred count | Number of occurrences |
| --- | --- | --- |
| `ism`   | 3501 | 3501 |
| `gæl`   |   41 |   42 |
| `örn`   |   26 |   95 |
| `fyr`   |   22 |  159 |
| `hetja` |   14 |   14 |
| `bær`   |   13 |   36 |
| `erm`   |    5 |    5 |
| `göt`   |    4 |   11 |
| `alm`   |    4 |    5 |
| `lönd`  |    3 |    6 |
| `heö`   |    3 |    4 |
| `erl`   |    3 |    9 |
| `ffl`   |    2 |    5 |
| `stja`  |    1 |    5 |
| `ætt`   |    1 |    1 |
| `mvirk` |    0 |    1 |
| `þor`   |    0 |    1 |
| `hug`   |    0 |    1 |

The _Preferred count_ is how often the category was picked when there were multiple categories to choose from.

The _Number of occurrences_ is the total number of times a legal Icelandic name existed in the category.


# Drive-by

## Always prefer first case variant

Some names have multiple valid declensions for a given case. For example:

> Nominative: Sigurberg
> Accusative: Sigurberg
> Dative: Sigurberg / Sigurbergi
> Genitive: Sigurbergs

This manifests like so in the `getCase` function:

```tsx
switch (caseString) {
  case "NFET":
    return Case.Nominative;
  case "ÞFET":
  case "ÞFET2":
  case "ÞFET3":
    /** @todo only use one of these, not both */
    return Case.Accusative;
  // ...
}
```

Because we process the input data line-by-line, the last entry in the input data wins. You would think that this means that the "highest variant" wins (e.g. `ÞFET3` always wins over `ÞFET`), but it doesn't! The input data is not consistent with the order.

```
...
Sigurberg;353385;kk;ism;1;;;353411;V;Sigurbergi;ÞGFET2;1;;;
Sigurberg;353385;kk;ism;1;;;353411;V;Sigurbergs;EFET;1;;;
Sigurberg;353385;kk;ism;1;;;353411;V;Sigurberg;NFET;1;;;
Sigurberg;353385;kk;ism;1;;;353411;V;Sigurberg;ÞFET;1;;;
Sigurberg;353385;kk;ism;1;;;353411;V;Sigurberg;ÞGFET;1;;;
...
Enok;354018;kk;ism;1;;;;K;Enok;ÞGFET;1;;;
Enok;354018;kk;ism;1;;;;K;Enoki;ÞGFET2;1;;;
Enok;354018;kk;ism;1;;;;K;Enoks;EFET;1;;;
Enok;354018;kk;ism;1;;;;K;Enok;NFET;1;;;
Enok;354018;kk;ism;1;;;;K;Enok;ÞFET;1;;;
...
```

For Sigurberg, `ÞGFET` wins. For Enok, `ÞGFET2` wins.

This also means that if the ordering in the input data changes, the behavior in Beygla also changes, making it volatile. That's not great.

To amend this issue, we now always prefer the first variant. This DOES affect the behavior of Beygla for some names (hence the change in `beygla.spec.ts`). There are 301 names with multiple declensions for some cases, which are potentially affected.


## Omit names with multiple genders

There are 11 names that that exist in multiple genders that can be declined in multiple ways. These also encounter the last-write-wins issue.

Because Beygla does not know the gender of input names, these names are omitted to avoid declining names in the incorrect gender.