### PR TITLE
Do not apply declensions when they cannot apply to to the name

### DIFF
--- a/lib/beygla.spec.ts
+++ b/lib/beygla.spec.ts
@@ -189,4 +189,17 @@ describe("applyCase", () => {
       expect(applyCase(_case, "Eldey")).toEqual(name);
     }
   });
+
+  test("it does not apply declensions that can not possibly apply to a name", () => {
+    // The name 'Maya' would previously match the declension for 'Tanya', which
+    // is '4;anya,önyu,önyu,önyu'.
+    //
+    // The subtraction of 4 would erase the entire name. Applying the declension
+    // is non-sensical.
+    expect(getDeclensionForName("Maya")).toEqual(null);
+
+    for (const caseStr of <const>["nf", "þf", "þgf", "ef"]) {
+      expect(applyCase(caseStr, "Maya")).toEqual("Maya");
+    }
+  });
 });


### PR DESCRIPTION
# What

The name "Maya" currently matches the declension for the name "Tanya" (the path to Tanya is "ya").

The declension for "Tanya" is `4;anya,önyu,önyu,önyu`. The subtraction of 4 erases the entire name "Maya", given that it is only 4 character long, which is nonsensical.

This PR prevents Beygla from applying cases that cannot possibly apply.

# How

If the `nf` ending does not match the provided name, do not apply the declension.