### PR TITLE
Add 'beygla/strict' module

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,9 @@ applyCase("þgf", "Helga Fríða Smáradóttir");
   - [Cases](#Cases)
   - [Whitespace](#Whitespace)
 - [Correctness](#Correctness)
-  - [Passing a name in the wrong case](Passing_a_name_in_the_wrong_case)
-  - [What happens if beygla does not find a pattern?](What_happens_if_beygla_does_not_find_a_pattern)
+  - [Strict mode](#Strict_mode)
+  - [Passing a name in the wrong case](#Passing_a_name_in_the_wrong_case)
+  - [What happens if beygla does not find a pattern?](#What_happens_if_beygla_does_not_find_a_pattern)
 
 ---
 
@@ -188,6 +189,20 @@ I tried randomly sampling 20 names from the list of legal Icelandic names not pr
 Even though I happened to get no incorrect results, this is a very small sample. I'm absolutely certain that there are a handful of names that will produce incorrect results.
 
 See [beygla.spec.ts](https://github.com/alexharri/beygla/blob/master/lib/beygla.spec.ts).
+
+<h3 id="Strict_mode">
+Strict mode
+</h3>
+
+Beygla provides a "strict version" accessible under `beygla/strict` which guarantees that declensions are only be applied to legal Icelandic names.
+
+```tsx
+import { applyCase } from "beygla/strict";
+```
+
+The interface for `beygla/strict` is the exact same as for `beygla`.
+
+Only declining Icelandic names may not be desirable when a correct declensions is not to applied to a foreign name. The `beygla/strict` module is also 15kB gzipped, which is three times larger than the standard `beygla` module.
 
 
 <h3 id="Passing_a_name_in_the_wrong_case">

--- a/lib/beygla.spec.ts
+++ b/lib/beygla.spec.ts
@@ -1,3 +1,4 @@
+import "./test/mock";
 import * as _beygla from "./beygla";
 import serializedInput from "./read/serializedInput";
 import groupedNames from "../out/grouped-names.json";
@@ -15,19 +16,6 @@ if (testingBuild) {
 }
 
 const { applyCase, getDeclensionForName } = beygla;
-
-jest.mock("./read/serializedInput", () => {
-  const fs = require("fs");
-  const path = require("path");
-
-  const serializedTrieFilePath = path.resolve(__dirname, "../out/trie-ser.txt");
-  const serializedTrie = fs.readFileSync(serializedTrieFilePath, "utf-8");
-
-  return {
-    __esModule: true,
-    default: serializedTrie,
-  };
-});
 
 describe("applyCase", () => {
   it("mocks the serialized input correctly", () => {

--- a/lib/beygla.spec.ts
+++ b/lib/beygla.spec.ts
@@ -2,192 +2,232 @@ import "./test/mock";
 import * as _beygla from "./beygla";
 import serializedInput from "./read/serializedInput";
 import groupedNames from "../out/grouped-names.json";
+import icelandicNamesList from "../out/icelandic-names.json";
+
+const icelandicNames = new Set(icelandicNamesList);
 
 let beygla = _beygla;
+
+// We only test the 'strict' module when the 'TEST_BUILD' parameter is
+// set to 'true' because the 'strict' module mutates global state in
+// beygla (via setPredicate).
+//
+// Global state is used to avoid polluting the interface of beygla's
+// main function, 'applyCase'.
+let beyglaStrict: typeof beygla | null = null;
 
 const testingBuild = process.env.TEST_BUILD === "true";
 if (testingBuild) {
   // We specifically check for the precense of 'Testing built module.' in
   // the 'test-build' script to make sure that we actually ran the test
   // on the build output.
-  console.log("Testing built module.");
+  console.log("Testing built modules.");
 
   beygla = require("../dist/beygla.esm.js");
+  beyglaStrict = require("../dist/strict.esm.js");
 }
 
-const { applyCase, getDeclensionForName } = beygla;
+runTests(beygla, false);
+if (beyglaStrict) runTests(beyglaStrict, true);
 
-describe("applyCase", () => {
-  it("mocks the serialized input correctly", () => {
-    expect(serializedInput).not.toEqual("@@input@@");
-    expect(serializedInput.startsWith("{")).toEqual(true);
-  });
+function runTests(beygla: typeof import("./beygla"), strict: boolean) {
+  const { applyCase, getDeclensionForName } = beygla;
 
-  it("applies a case to a name", () => {
-    const sourceName = "Jóhannes";
+  describe(strict ? "beygla/strict" : "beygla", () => {
+    describe("applyCase", () => {
+      it("mocks the serialized input correctly", () => {
+        expect(serializedInput).not.toEqual("@@input@@");
+        expect(serializedInput.startsWith("{")).toEqual(true);
+      });
 
-    const out = applyCase("ef", sourceName);
+      it("applies a case to a name", () => {
+        const sourceName = "Jóhannes";
 
-    expect(out).toEqual("Jóhannesar");
-  });
+        const out = applyCase("ef", sourceName);
 
-  it("correctly applies every case to every name", () => {
-    for (const names of groupedNames) {
-      const nameInNominative = names[0];
+        expect(out).toEqual("Jóhannesar");
+      });
 
-      const cases = ["nf", "þf", "þgf", "ef"] as const;
-      for (const [i, caseStr] of cases.entries()) {
-        const nameInCase = applyCase(caseStr, nameInNominative);
+      if (!strict) {
+        it("correctly applies every case to every name", () => {
+          for (const names of groupedNames) {
+            const nameInNominative = names[0];
 
-        expect(nameInCase).toEqual(names[i]);
+            const cases = ["nf", "þf", "þgf", "ef"] as const;
+            for (const [i, caseStr] of cases.entries()) {
+              const nameInCase = applyCase(caseStr, nameInNominative);
+
+              expect(nameInCase).toEqual(names[i]);
+            }
+          }
+        });
       }
-    }
-  });
 
-  it("applies a cases to an input string as if it were a name", () => {
-    type Case = "nf" | "þf" | "þgf" | "ef";
-    type Test = [source: string, caseStr: Case, expected: string];
-    const tests: Test[] = [
-      ["fantasía", "þf", "fantasíu"],
-      ["Mamma", "ef", "Mömmu"],
-    ];
+      if (strict) {
+        it("correctly applies every case to every name in the 'icelandic-names' list", () => {
+          for (const names of groupedNames) {
+            const nameInNominative = names[0];
 
-    for (const [source, caseStr, expected] of tests) {
-      const out = applyCase(caseStr, source);
+            if (!icelandicNames.has(nameInNominative)) continue;
 
-      expect(out).toEqual(expected);
-    }
-  });
+            const cases = ["nf", "þf", "þgf", "ef"] as const;
+            for (const [i, caseStr] of cases.entries()) {
+              const nameInCase = applyCase(caseStr, nameInNominative);
 
-  it("applies a case to a full name", () => {
-    const sourceName = "Gunnar Sigurberg Brjánsson";
-
-    const out = applyCase("þgf", sourceName);
-
-    expect(out).toEqual("Gunnari Sigurberg Brjánssyni");
-  });
-
-  it("strips whitespace in full names", () => {
-    const sourceName = "  \n  Hildigerður  Oddný\tPatreksdóttir  \n\n";
-
-    const out = applyCase("þf", sourceName);
-
-    expect(out).toEqual("Hildigerði Oddnýju Patreksdóttur");
-  });
-
-  it("applies a case to a first and middle name", () => {
-    const sourceName = "Þorleifur Sigþór";
-
-    const out = applyCase("ef", sourceName);
-
-    expect(out).toEqual("Þorleifs Sigþórs");
-  });
-
-  it("applies a case only the last name", () => {
-    const sourceName = "Ríkharðsdóttir";
-
-    const out = applyCase("ef", sourceName);
-
-    expect(out).toEqual("Ríkharðsdóttur");
-  });
-
-  it("applies cases to suffixes as expected", () => {
-    const cases = ["nf", "þf", "þgf", "ef"] as const;
-    const nameGroups = [
-      ["Jónsson", "Jónsson", "Jónssyni", "Jónssonar"],
-      ["Jónsdóttir", "Jónsdóttur", "Jónsdóttur", "Jónsdóttur"],
-      ["Jónsbur", "Jónsbur", "Jónsburi", "Jónsburs"],
-    ];
-
-    for (const group of nameGroups) {
-      const base = group[0];
-
-      for (const [i, caseStr] of cases.entries()) {
-        expect(applyCase(caseStr, base)).toEqual(group[i]);
+              expect(nameInCase).toEqual(names[i]);
+            }
+          }
+        });
       }
-    }
+
+      if (!strict) {
+        it("applies a cases to an input string as if it were a name", () => {
+          type Case = "nf" | "þf" | "þgf" | "ef";
+          type Test = [source: string, caseStr: Case, expected: string];
+          const tests: Test[] = [
+            ["fantasía", "þf", "fantasíu"],
+            ["Mamma", "ef", "Mömmu"],
+          ];
+
+          for (const [source, caseStr, expected] of tests) {
+            const out = applyCase(caseStr, source);
+
+            expect(out).toEqual(expected);
+          }
+        });
+      }
+
+      it("applies a case to a full name", () => {
+        const sourceName = "Gunnar Sigurberg Brjánsson";
+
+        const out = applyCase("þgf", sourceName);
+
+        expect(out).toEqual("Gunnari Sigurberg Brjánssyni");
+      });
+
+      it("strips whitespace in full names", () => {
+        const sourceName = "  \n  Hildigerður  Oddný\tPatreksdóttir  \n\n";
+
+        const out = applyCase("þf", sourceName);
+
+        expect(out).toEqual("Hildigerði Oddnýju Patreksdóttur");
+      });
+
+      it("applies a case to a first and middle name", () => {
+        const sourceName = "Þorleifur Sigþór";
+
+        const out = applyCase("ef", sourceName);
+
+        expect(out).toEqual("Þorleifs Sigþórs");
+      });
+
+      it("applies a case only the last name", () => {
+        const sourceName = "Ríkharðsdóttir";
+
+        const out = applyCase("ef", sourceName);
+
+        expect(out).toEqual("Ríkharðsdóttur");
+      });
+
+      it("applies cases to suffixes as expected", () => {
+        const cases = ["nf", "þf", "þgf", "ef"] as const;
+        const nameGroups = [
+          ["Jónsson", "Jónsson", "Jónssyni", "Jónssonar"],
+          ["Jónsdóttir", "Jónsdóttur", "Jónsdóttur", "Jónsdóttur"],
+          ["Jónsbur", "Jónsbur", "Jónsburi", "Jónsburs"],
+        ];
+
+        for (const group of nameGroups) {
+          const base = group[0];
+
+          for (const [i, caseStr] of cases.entries()) {
+            expect(applyCase(caseStr, base)).toEqual(group[i]);
+          }
+        }
+      });
+
+      it("applies a case to the first and last name", () => {
+        const sourceName = "Magnús Herleifsson";
+
+        const out = applyCase("þgf", sourceName);
+
+        expect(out).toEqual("Magnúsi Herleifssyni");
+      });
+
+      it("applies a case to only 'son' or 'dóttir'", () => {
+        const son = applyCase("þgf", "son");
+        const dottir = applyCase("þgf", "dóttir");
+
+        expect(son).toEqual("syni");
+        expect(dottir).toEqual("dóttur");
+      });
+
+      it("finds correct declension for some unknown names", () => {
+        const tests: Array<[name: string, declension: string]> = [
+          ["Sotti", "1;i,a,a,a"],
+          ["Sófía", "1;a,u,u,u"],
+          ["Kórekur", "2;ur,,i,s"],
+          ["Olivia", "1;a,u,u,u"],
+          ["Caritas", "0;,,,ar"],
+          ["Hávarr", "1;r,,i,s"],
+          ["Ermenga", "1;a,u,u,u"],
+          ["Fannþór", "0;,,i,s"],
+          ["Ísbrá", "0;,,,r"],
+          ["Sófús", "0;,,i,ar"],
+          ["Kristólín", "0;,,,ar"],
+          ["Jasper", "0;,,,s"],
+          ["Agok", "0;,,,s"],
+        ];
+
+        for (const [name, declension] of tests) {
+          expect(`${name}: ${getDeclensionForName(name)}`).toEqual(
+            `${name}: ${declension}`
+          );
+        }
+      });
+
+      it("does not find a declension for some unknown names", () => {
+        const tests: string[] = [
+          "Emanuel",
+          "Frederik",
+          "Evan",
+          "Lennon",
+          "Artemis",
+          "Kaín",
+        ];
+
+        for (const name of tests) {
+          expect(`${name}: ${getDeclensionForName(name)}`).toEqual(
+            `${name}: ${null}`
+          );
+        }
+      });
+
+      test("it uses the declensions for the person, not the company/organization", () => {
+        const tests = [
+          ["nf", "Eldey"],
+          ["þf", "Eldeyju"],
+          ["þgf", "Eldeyju"],
+          ["ef", "Eldeyjar"],
+        ] as const;
+
+        for (const [_case, name] of tests) {
+          expect(applyCase(_case, "Eldey")).toEqual(name);
+        }
+      });
+
+      test("it does not apply declensions that can not possibly apply to a name", () => {
+        // The name 'Maya' would previously match the declension for 'Tanya', which
+        // is '4;anya,önyu,önyu,önyu'.
+        //
+        // The subtraction of 4 would erase the entire name. Applying the declension
+        // is non-sensical.
+        expect(getDeclensionForName("Maya")).toEqual(null);
+
+        for (const caseStr of <const>["nf", "þf", "þgf", "ef"]) {
+          expect(applyCase(caseStr, "Maya")).toEqual("Maya");
+        }
+      });
+    });
   });
-
-  it("applies a case to the first and last name", () => {
-    const sourceName = "Magnús Herleifsson";
-
-    const out = applyCase("þgf", sourceName);
-
-    expect(out).toEqual("Magnúsi Herleifssyni");
-  });
-
-  it("applies a case to only 'son' or 'dóttir'", () => {
-    const son = applyCase("þgf", "son");
-    const dottir = applyCase("þgf", "dóttir");
-
-    expect(son).toEqual("syni");
-    expect(dottir).toEqual("dóttur");
-  });
-
-  it("finds correct declension for some unknown names", () => {
-    const tests: Array<[name: string, declension: string]> = [
-      ["Sotti", "1;i,a,a,a"],
-      ["Sófía", "1;a,u,u,u"],
-      ["Kórekur", "2;ur,,i,s"],
-      ["Olivia", "1;a,u,u,u"],
-      ["Caritas", "0;,,,ar"],
-      ["Hávarr", "1;r,,i,s"],
-      ["Ermenga", "1;a,u,u,u"],
-      ["Fannþór", "0;,,i,s"],
-      ["Ísbrá", "0;,,,r"],
-      ["Sófús", "0;,,i,ar"],
-      ["Kristólín", "0;,,,ar"],
-      ["Jasper", "0;,,,s"],
-      ["Agok", "0;,,,s"],
-    ];
-
-    for (const [name, declension] of tests) {
-      expect(`${name}: ${getDeclensionForName(name)}`).toEqual(
-        `${name}: ${declension}`
-      );
-    }
-  });
-
-  it("does not find a declension for some unknown names", () => {
-    const tests: string[] = [
-      "Emanuel",
-      "Frederik",
-      "Evan",
-      "Lennon",
-      "Artemis",
-      "Kaín",
-    ];
-
-    for (const name of tests) {
-      expect(`${name}: ${getDeclensionForName(name)}`).toEqual(
-        `${name}: ${null}`
-      );
-    }
-  });
-
-  test("it uses the declensions for the person, not the company/organization", () => {
-    const tests = [
-      ["nf", "Eldey"],
-      ["þf", "Eldeyju"],
-      ["þgf", "Eldeyju"],
-      ["ef", "Eldeyjar"],
-    ] as const;
-
-    for (const [_case, name] of tests) {
-      expect(applyCase(_case, "Eldey")).toEqual(name);
-    }
-  });
-
-  test("it does not apply declensions that can not possibly apply to a name", () => {
-    // The name 'Maya' would previously match the declension for 'Tanya', which
-    // is '4;anya,önyu,önyu,önyu'.
-    //
-    // The subtraction of 4 would erase the entire name. Applying the declension
-    // is non-sensical.
-    expect(getDeclensionForName("Maya")).toEqual(null);
-
-    for (const caseStr of <const>["nf", "þf", "þgf", "ef"]) {
-      expect(applyCase(caseStr, "Maya")).toEqual("Maya");
-    }
-  });
-});
+}

--- a/lib/beygla.spec.ts
+++ b/lib/beygla.spec.ts
@@ -228,6 +228,18 @@ function runTests(beygla: typeof import("./beygla"), strict: boolean) {
           expect(applyCase(caseStr, "Maya")).toEqual("Maya");
         }
       });
+
+      if (strict) {
+        it("does not apply cases to non-Icelandic names", () => {
+          expect(applyCase("þgf", "Carlos")).toEqual("Carlos");
+        });
+      }
+
+      if (!strict) {
+        it("applies cases to non-Icelandic names", () => {
+          expect(applyCase("þgf", "Carlos")).toEqual("Carlosi");
+        });
+      }
     });
   });
 }

--- a/lib/beygla.spec.ts
+++ b/lib/beygla.spec.ts
@@ -18,7 +18,7 @@ let beyglaStrict: typeof beygla | null = null;
 
 const testingBuild = process.env.TEST_BUILD === "true";
 if (testingBuild) {
-  // We specifically check for the precense of 'Testing built module.' in
+  // We specifically check for the precense of 'Testing built modules.' in
   // the 'test-build' script to make sure that we actually ran the test
   // on the build output.
   console.log("Testing built modules.");

--- a/lib/beygla.ts
+++ b/lib/beygla.ts
@@ -59,7 +59,7 @@ export function setPredicate(pred: typeof predicate) {
 function applyCaseToName(caseStr: Case, name: string) {
   let postfix: [string, string] | null = null;
 
-  const endsWithSon = namesThatEndWithSon.includes(name);
+  const endsWithSon = namesThatEndWithSon.indexOf(name) !== -1;
   if (!endsWithSon) {
     for (const [ending, declension] of [
       ["son", "2;on,on,yni,onar"],

--- a/lib/beygla.ts
+++ b/lib/beygla.ts
@@ -51,8 +51,8 @@ function declineName(name: string, declension: string, caseStr: Case): string {
 
 const namesThatEndWithSon = ["Samson", "Jason"];
 
-let predicate: any;
-export function setPredicate(pred: any) {
+let predicate: ((name: string) => boolean) | null;
+export function setPredicate(pred: typeof predicate) {
   predicate = pred;
 }
 

--- a/lib/beygla.ts
+++ b/lib/beygla.ts
@@ -4,7 +4,7 @@ import serializedInput from "./read/serializedInput";
 
 const trie = deserializeTrie(serializedInput);
 
-export type Case =
+type Case =
   // Icelandic cases
   | "nf"
   | "þf"

--- a/lib/beygla.ts
+++ b/lib/beygla.ts
@@ -4,7 +4,7 @@ import serializedInput from "./read/serializedInput";
 
 const trie = deserializeTrie(serializedInput);
 
-type Case =
+export type Case =
   // Icelandic cases
   | "nf"
   | "þf"
@@ -50,6 +50,11 @@ function declineName(name: string, declension: string, caseStr: Case): string {
 }
 
 const namesThatEndWithSon = ["Samson", "Jason"];
+
+let predicate: any;
+export function setPredicate(pred: any) {
+  predicate = pred;
+}
 
 function applyCaseToName(caseStr: Case, name: string) {
   let postfix: [string, string] | null = null;
@@ -110,8 +115,13 @@ function applyCaseToName(caseStr: Case, name: string) {
  * @param caseStr - The case to apply to the name to, e.g. `þf`
  */
 export function applyCase(caseStr: Case, name: string): string {
-  const names = name.split(/\s+/).filter(Boolean);
-  return names.map((name) => applyCaseToName(caseStr, name)).join(" ");
+  return name
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((name) =>
+      !predicate || predicate(name) ? applyCaseToName(caseStr, name) : name
+    )
+    .join(" ");
 }
 
 export function getDeclensionForName(name: string): string | null {

--- a/lib/beygla.ts
+++ b/lib/beygla.ts
@@ -59,20 +59,23 @@ export function setPredicate(pred: any) {
 function applyCaseToName(caseStr: Case, name: string) {
   let postfix: [string, string] | null = null;
 
-  for (const [ending, declension] of [
-    ["son", "2;on,on,yni,onar"],
-    ["dóttir", "2;ir,ur,ur,ur"],
-    ["bur", "0;,,i,s"],
-  ]) {
-    if (!name.endsWith(ending)) continue;
-    if (namesThatEndWithSon.indexOf(name) !== -1) continue;
-    postfix = [ending, declension];
-    name = name.split(ending)[0];
+  const endsWithSon = namesThatEndWithSon.includes(name);
+  if (!endsWithSon) {
+    for (const [ending, declension] of [
+      ["son", "2;on,on,yni,onar"],
+      ["dóttir", "2;ir,ur,ur,ur"],
+      ["bur", "0;,,i,s"],
+    ]) {
+      if (!name.endsWith(ending)) continue;
+      postfix = [ending, declension];
+      name = name.split(ending)[0];
+    }
   }
 
   if (!postfix) {
     const declension = getDeclensionForName(name);
-    if (declension) name = declineName(name, declension, caseStr);
+    if (declension && (!predicate || predicate(name)))
+      name = declineName(name, declension, caseStr);
   } else {
     name += declineName(postfix[0], postfix[1], caseStr);
   }
@@ -118,9 +121,7 @@ export function applyCase(caseStr: Case, name: string): string {
   return name
     .split(/\s+/)
     .filter(Boolean)
-    .map((name) =>
-      !predicate || predicate(name) ? applyCaseToName(caseStr, name) : name
-    )
+    .map((name) => applyCaseToName(caseStr, name))
     .join(" ");
 }
 

--- a/lib/compress/types.ts
+++ b/lib/compress/types.ts
@@ -29,7 +29,7 @@ export interface DeclinedName {
   name: string;
   case: Case;
   gender: string;
-  category: WordCategory;
+  categories: WordCategory[];
 }
 
 export interface UnprocessedName {
@@ -37,5 +37,5 @@ export interface UnprocessedName {
   name: string;
   case: string;
   gender: string;
-  category: WordCategory;
+  categories: WordCategory[];
 }

--- a/lib/names/encode.spec.ts
+++ b/lib/names/encode.spec.ts
@@ -1,0 +1,45 @@
+import "../test/mock";
+
+import { getNames } from "../preprocess/data/getNames";
+import { encodeNames } from "./encode";
+import { decodeNames } from "../strict";
+
+const firstUpper = (s: string) => s[0].toUpperCase() + s.substr(1);
+
+interface Node {
+  e: number; // end
+  c: Record<string, Node>; // children
+}
+
+export const makeTrieNode = (): Node => ({ e: 0, c: {} });
+
+export function decodedTrieToSet(trie: Node) {
+  const set = new Set<string>();
+
+  function iter(node: Node, stack: string[]) {
+    if (node.e) set.add(firstUpper(stack.join("")));
+    const entries = Object.entries(node.c) as [string, Node][];
+    for (const [char, next] of entries) {
+      stack.push(char);
+      iter(next, stack);
+      stack.pop();
+    }
+  }
+  iter(trie, []);
+
+  return set;
+}
+
+describe("encode and decode names", () => {
+  it("it correctly encodes and decodes the set of Icelandic names", () => {
+    const names = getNames();
+
+    const expectedNameSet = new Set(names);
+
+    const encoded = encodeNames(expectedNameSet);
+    const decodedAsTrie = decodeNames(encoded);
+    const decodedNameSet = decodedTrieToSet(decodedAsTrie);
+
+    expect(decodedNameSet).toEqual(expectedNameSet);
+  });
+});

--- a/lib/names/encode.spec.ts
+++ b/lib/names/encode.spec.ts
@@ -11,9 +11,7 @@ interface Node {
   c: Record<string, Node>; // children
 }
 
-export const makeTrieNode = (): Node => ({ e: 0, c: {} });
-
-export function decodedTrieToSet(trie: Node) {
+function decodedTrieToSet(trie: Node) {
   const set = new Set<string>();
 
   function iter(node: Node, stack: string[]) {

--- a/lib/names/encode.spec.ts
+++ b/lib/names/encode.spec.ts
@@ -6,17 +6,17 @@ import { decodeNames } from "../strict";
 
 const firstUpper = (s: string) => s[0].toUpperCase() + s.substr(1);
 
-interface Node {
+interface TrieNode {
   e: number; // end
-  c: Record<string, Node>; // children
+  c: Record<string, TrieNode>; // children
 }
 
-function decodedTrieToSet(trie: Node) {
+function decodedTrieToSet(trie: TrieNode) {
   const set = new Set<string>();
 
-  function iter(node: Node, stack: string[]) {
+  function iter(node: TrieNode, stack: string[]) {
     if (node.e) set.add(firstUpper(stack.join("")));
-    const entries = Object.entries(node.c) as [string, Node][];
+    const entries = Object.entries(node.c) as [string, TrieNode][];
     for (const [char, next] of entries) {
       stack.push(char);
       iter(next, stack);

--- a/lib/names/encode.ts
+++ b/lib/names/encode.ts
@@ -1,16 +1,16 @@
-interface Node {
+interface TrieNode {
   end: boolean;
-  children: Record<string, Node>;
+  children: Record<string, TrieNode>;
 }
 
 const isChars = "áðéíóúþæö";
 
-function emptyNode(): Node {
+function emptyNode(): TrieNode {
   return { children: {}, end: false };
 }
 
 export function encodeNames(names: Set<string>): string {
-  const root: Node = emptyNode();
+  const root: TrieNode = emptyNode();
 
   function add(name: string) {
     let curr = root;
@@ -27,7 +27,7 @@ export function encodeNames(names: Set<string>): string {
   for (const name of names) add(name);
 
   const chars: string[] = [];
-  function iter(char: string, curr: Node) {
+  function iter(char: string, curr: TrieNode) {
     const isCharIndex = isChars.indexOf(char);
     if (isCharIndex !== -1) {
       chars.push("'"); // Denotes an Icelandic character

--- a/lib/names/encode.ts
+++ b/lib/names/encode.ts
@@ -3,8 +3,6 @@ interface TrieNode {
   children: Record<string, TrieNode>;
 }
 
-const isChars = "áðéíóúþæö";
-
 function emptyNode(): TrieNode {
   return { children: {}, end: false };
 }
@@ -28,11 +26,6 @@ export function encodeNames(names: Set<string>): string {
 
   const chars: string[] = [];
   function iter(char: string, curr: TrieNode) {
-    const isCharIndex = isChars.indexOf(char);
-    if (isCharIndex !== -1) {
-      chars.push("'"); // Denotes an Icelandic character
-      char = String(isCharIndex);
-    }
     chars.push(char);
     if (curr.end) chars.push(".");
 

--- a/lib/names/encode.ts
+++ b/lib/names/encode.ts
@@ -1,0 +1,51 @@
+interface Node {
+  end: boolean;
+  children: Record<string, Node>;
+}
+
+const isChars = "áðéíóúþæö";
+
+function emptyNode(): Node {
+  return { children: {}, end: false };
+}
+
+export function encodeNames(names: Set<string>): string {
+  const root: Node = emptyNode();
+
+  function add(name: string) {
+    let curr = root;
+    const chars = name.split("").map((s) => s.toLowerCase());
+    for (const char of chars) {
+      if (!curr.children[char]) {
+        curr.children[char] = emptyNode();
+      }
+      curr = curr.children[char];
+    }
+    curr.end = true;
+  }
+
+  for (const name of names) add(name);
+
+  const chars: string[] = [];
+  function iter(char: string, curr: Node) {
+    const isCharIndex = isChars.indexOf(char);
+    if (isCharIndex !== -1) {
+      chars.push("'"); // Denotes an Icelandic character
+      char = String(isCharIndex);
+    }
+    chars.push(char);
+    if (curr.end) chars.push(".");
+
+    const children = Object.entries(curr.children);
+    for (const [key, value] of children) {
+      iter(key, value);
+    }
+    chars.push("<");
+  }
+
+  for (const [key, next] of Object.entries(root.children)) {
+    iter(key, next);
+  }
+
+  return chars.join("");
+}

--- a/lib/preprocess/data/getNames.ts
+++ b/lib/preprocess/data/getNames.ts
@@ -6,5 +6,6 @@ export function getNames(): string[] {
     path.resolve(__dirname, "../../../out/icelandic-names.json"),
     "utf-8"
   );
-  return JSON.parse(fileContent);
+  const names = JSON.parse(fileContent) as string[];
+  return names.filter((name) => !name.includes(" "));
 }

--- a/lib/preprocess/format/name.ts
+++ b/lib/preprocess/format/name.ts
@@ -27,7 +27,7 @@ export function getRawName(line: string): UnprocessedName {
     base,
     case: caseString,
     name,
-    category: category as WordCategory,
+    categories: category.split(",") as WordCategory[],
     gender,
   };
 }
@@ -39,7 +39,7 @@ export function formatName(name: UnprocessedName): DeclinedName {
     base: name.base,
     name: name.name,
     case: nameCase,
-    category: name.category,
+    categories: name.categories,
     gender: name.gender,
   };
 }

--- a/lib/read/serializedNames.ts
+++ b/lib/read/serializedNames.ts
@@ -1,0 +1,1 @@
+export default "@@input@@";

--- a/lib/strict.ts
+++ b/lib/strict.ts
@@ -1,0 +1,51 @@
+import { setPredicate } from "./beygla";
+import serializedNames from "./read/serializedNames";
+
+interface TrieNode {
+  e: number; // end
+  c: Record<string, TrieNode>; // children
+}
+
+export function decodeNames(data: string): TrieNode {
+  const stack: TrieNode[] = [{ e: 0, c: {} }];
+
+  for (let i = 0; i < data.length; i++) {
+    let char = data[i];
+    let node = stack[stack.length - 1];
+    if (char === ".") {
+      node.e = 1;
+    } else if (char === "<") {
+      stack.pop();
+    } else {
+      if (char === "'") {
+        char = "áðéíóúþæö"[+data[i + 1]];
+        ++i;
+      }
+      stack.push((node.c[char] ||= { e: 0, c: {} }));
+    }
+  }
+
+  return stack[0];
+}
+
+const trie = decodeNames(serializedNames);
+
+const endings = ["son", "dóttir", "bur"];
+
+function predicate(name: string): boolean {
+  name = name.toLowerCase();
+
+  endings.forEach((ending) => {
+    if (name.endsWith(ending))
+      name = name.substring(0, name.length - ending.length);
+  });
+
+  let curr = trie;
+  for (let i = 0; curr && i < name.length; i++) {
+    curr = curr.c[name[i]];
+  }
+  return !!(curr && curr.e);
+}
+setPredicate(predicate);
+
+export * from "./beygla";

--- a/lib/strict.ts
+++ b/lib/strict.ts
@@ -30,16 +30,8 @@ export function decodeNames(data: string): TrieNode {
 
 const trie = decodeNames(serializedNames);
 
-const endings = ["son", "dóttir", "bur"];
-
 function predicate(name: string): boolean {
   name = name.toLowerCase();
-
-  endings.forEach((ending) => {
-    if (name.endsWith(ending))
-      name = name.substring(0, name.length - ending.length);
-  });
-
   let curr = trie;
   for (let i = 0; curr && i < name.length; i++) {
     curr = curr.c[name[i]];

--- a/lib/strict.ts
+++ b/lib/strict.ts
@@ -17,7 +17,6 @@ export function decodeNames(data: string): TrieNode {
     } else if (char === "<") {
       stack.pop();
     } else {
-      if (char === "'") char = "áðéíóúþæö"[+data[++i]];
       stack.push((node.c[char] ||= { e: 0, c: {} }));
     }
   }

--- a/lib/strict.ts
+++ b/lib/strict.ts
@@ -17,10 +17,7 @@ export function decodeNames(data: string): TrieNode {
     } else if (char === "<") {
       stack.pop();
     } else {
-      if (char === "'") {
-        char = "áðéíóúþæö"[+data[i + 1]];
-        ++i;
-      }
+      if (char === "'") char = "áðéíóúþæö"[+data[++i]];
       stack.push((node.c[char] ||= { e: 0, c: {} }));
     }
   }

--- a/lib/strict.ts
+++ b/lib/strict.ts
@@ -26,7 +26,7 @@ export function decodeNames(data: string): TrieNode {
 
 const trie = decodeNames(serializedNames);
 
-function predicate(name: string): boolean {
+function isIcelandicName(name: string): boolean {
   name = name.toLowerCase();
   let curr = trie;
   for (let i = 0; curr && i < name.length; i++) {
@@ -34,6 +34,6 @@ function predicate(name: string): boolean {
   }
   return !!(curr && curr.e);
 }
-setPredicate(predicate);
+setPredicate(isIcelandicName);
 
 export * from "./beygla";

--- a/lib/test/mock.ts
+++ b/lib/test/mock.ts
@@ -1,0 +1,15 @@
+jest.mock("../read/serializedInput", () => {
+  const fs = require("fs");
+  const path = require("path");
+
+  const serializedTrieFilePath = path.resolve(
+    __dirname,
+    "../../out/trie-ser.txt"
+  );
+  const serializedTrie = fs.readFileSync(serializedTrieFilePath, "utf-8");
+
+  return {
+    __esModule: true,
+    default: serializedTrie,
+  };
+});

--- a/lib/test/mock.ts
+++ b/lib/test/mock.ts
@@ -13,3 +13,19 @@ jest.mock("../read/serializedInput", () => {
     default: serializedTrie,
   };
 });
+
+jest.mock("../read/serializedNames", () => {
+  const fs = require("fs");
+  const path = require("path");
+
+  const serializedNamesFilePath = path.resolve(
+    __dirname,
+    "../../out/names-ser.txt"
+  );
+  const serializedNames = fs.readFileSync(serializedNamesFilePath, "utf-8");
+
+  return {
+    __esModule: true,
+    default: serializedNames,
+  };
+});

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,7 +1,7 @@
 import typescript from "@rollup/plugin-typescript";
 
-const config = {
-  input: "lib/beygla.ts",
+const mainConfig = {
+  input: ["lib/beygla.ts"],
   external: [],
   output: [
     { file: `dist/beygla.js`, format: "cjs", exports: "auto" },
@@ -16,5 +16,21 @@ const config = {
     }),
   ],
 };
+const strictConfig = {
+  input: ["lib/strict.ts"],
+  external: [],
+  output: [
+    { file: `dist/strict.js`, format: "cjs", exports: "auto" },
+    { file: `dist/strict.esm.js`, format: "es" },
+  ],
+  plugins: [
+    typescript({
+      tsconfig: "./tsconfig.declaration.json",
 
-export default config;
+      declaration: true,
+      declarationDir: "../dist-types",
+    }),
+  ],
+};
+
+export default [mainConfig, strictConfig];

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -23,12 +23,18 @@ async function main() {
   // Remove 'dist/common/' and 'dist/read/'
   run(`rm -rf dist/common/ dist/read/`);
 
-  const emittedJsFileNames = ["beygla.js", "beygla.esm.js"];
+  const emittedJsFileNames = [
+    "beygla.js",
+    "beygla.esm.js",
+    "strict.js",
+    "strict.esm.js",
+  ];
 
   const filesThatShouldExist = new Set([
     "package.json",
     "README.md",
     "beygla.d.ts",
+    "strict.d.ts",
     ...emittedJsFileNames,
   ]);
 
@@ -50,6 +56,10 @@ async function main() {
     path.resolve(OUT_DIR, "./trie-ser.txt"),
     "utf-8"
   );
+  const serializedNames = fs.readFileSync(
+    path.resolve(OUT_DIR, "./names-ser.txt"),
+    "utf-8"
+  );
 
   if (serializedTrie.length < 1000) {
     throw new Error(
@@ -69,6 +79,17 @@ async function main() {
       `serializedInput = "@@input@@"`,
       `serializedInput = "${serializedTrie}"`
     );
+    if (fileName.startsWith("strict")) {
+      if (!fileContent.includes(`serializedNames = "@@input@@"`)) {
+        throw new Error(
+          `Expected '${fileName}' to include 'serializedNames = "@@input@@"'`
+        );
+      }
+      fileContent = fileContent.replace(
+        `serializedNames = "@@input@@"`,
+        `serializedNames = "${serializedNames}"`
+      );
+    }
     fs.writeFileSync(filePath, fileContent, "utf-8");
   }
 

--- a/scripts/filter-names.ts
+++ b/scripts/filter-names.ts
@@ -25,6 +25,7 @@ async function main() {
   const nameSet = new Set(getNames());
 
   for await (const line of inputFile.readLines()) {
+    if (line === "") continue;
     nInputLines++;
 
     const name = getRawName(line);

--- a/scripts/group-names.ts
+++ b/scripts/group-names.ts
@@ -56,6 +56,7 @@ async function main() {
   const groups: Record<string, DeclinedName[]> = {};
 
   for (const line of lines) {
+    if (line === "") continue;
     const rawName = getRawName(line);
 
     if (!nameSet.has(rawName.base)) {
@@ -104,26 +105,17 @@ async function main() {
         default:
           throw new Error(`Unexpected case '${name.case}'`);
       }
-      byCategory[name.category] ||= {};
-      byCategory[name.category][name.gender] ||= {};
-      byCategory[name.category][name.gender][_case] ||= name;
+      for (const category of name.categories) {
+        byCategory[category] ||= {};
+        byCategory[category][name.gender] ||= {};
+        byCategory[category][name.gender][_case] ||= name;
+      }
     }
 
     let category: string | undefined;
     const categories = Object.keys(byCategory);
 
     assert(categories.length > 0, "should have at least 1 category");
-
-    if (
-      categories.length === 1 &&
-      ["gæl,ism", "dýr,hetja"].includes(categories[0])
-    ) {
-      // This seems like a data entry error, for which BÍN should be contacted.
-      // These occur for 1 word each.
-      //
-      // Anyway, ignore these while they are sorted out in the source.
-      continue;
-    }
 
     for (const preferredCategory of categoriesInOrderOfPreference) {
       if (categories.includes(preferredCategory)) {

--- a/scripts/process-names.ts
+++ b/scripts/process-names.ts
@@ -4,10 +4,13 @@ import { createAndPopulateTrie } from "../lib/compress/trie/createTrie";
 import { serializeTrie } from "../lib/compress/trie/serialize";
 import { deserializeTrie } from "../lib/read/deserialize";
 import { writeAndLogSize } from "../lib/preprocess/utils/gzip";
+import { encodeNames } from "../lib/names/encode";
+import { getNames } from "../lib/preprocess/data/getNames";
 
 const filePath = path.resolve(__dirname, "../out/grouped-names.json");
 const outFile = path.resolve(__dirname, "../out/trie-full.json");
-const serializedFile = path.resolve(__dirname, "../out/trie-ser.txt");
+const serializedTrieFileName = path.resolve(__dirname, "../out/trie-ser.txt");
+const serializedNamesFileName = path.resolve(__dirname, "../out/names-ser.txt");
 const deserializedJsonFile = path.resolve(__dirname, "../out/trie-deser.json");
 
 async function main() {
@@ -17,12 +20,15 @@ async function main() {
 
   writeAndLogSize(outFile, JSON.stringify(trie));
 
-  const serialized = serializeTrie(trie.getTrie());
-  writeAndLogSize(serializedFile, serialized);
+  const serializedTrie = serializeTrie(trie.getTrie());
+  writeAndLogSize(serializedTrieFileName, serializedTrie);
   writeAndLogSize(
     deserializedJsonFile,
-    JSON.stringify(deserializeTrie(serialized))
+    JSON.stringify(deserializeTrie(serializedTrie))
   );
+
+  const serializedNames = encodeNames(new Set(getNames()));
+  writeAndLogSize(serializedNamesFileName, serializedNames);
 }
 
 main();

--- a/scripts/test-build.ts
+++ b/scripts/test-build.ts
@@ -13,8 +13,8 @@ console.log(
       .join("\n")
 );
 
-if (!output.includes("Testing built module.")) {
-  throw new Error(`Expected test output to include 'Testing built module'.`);
+if (!output.includes("Testing built modules.")) {
+  throw new Error(`Expected test output to include 'Testing built modules'.`);
 }
 
 console.log(`Ran test build successfully.`);

--- a/tsconfig.declaration.json
+++ b/tsconfig.declaration.json
@@ -5,20 +5,9 @@
     "noUnusedLocals": true,
     "noImplicitAny": true,
     "esModuleInterop": true,
-    "lib": [
-      "es2020",
-    ],
-    "types": [
-      "jest",
-      "node",
-    ]
+    "lib": ["es2020"],
+    "types": ["jest", "node"]
   },
-  "include": [
-    "lib/beygla.ts",
-    "rollup.config.ts"
-  ],
-  "exclude": [
-    "lib/**/*.spec.ts",
-    "lib/**/*.typecheck.ts",
-  ]
+  "include": ["lib/beygla.ts", "lib/strict.ts", "rollup.config.ts"],
+  "exclude": ["lib/**/*.spec.ts", "lib/**/*.typecheck.ts"]
 }


### PR DESCRIPTION
Closes #14

# What

Adds a new `strict` version of `beygla`, which is accessed under `beygla/strict`:

```tsx
import { applyCase } from "beygla/strict";
```

There are two main differences between `beygla` and `beygla/strict`:

 * `beygla` declines all names it finds a pattern for. `beygla/strict` only declines Icelandic names (as specified in `icelandic-names.csv`).
 * `beygla` is <5kB while `beygla/strict` is <15kB.

The reason for the 3x size increase is that the `beygla/strict` version encodes all legal Icelandic names and bundles them in the library.

Because only known names are declined in `beygla/strict`, the declensions are guaranteed to be correct. The tradeoff, aside from the bundle size, is that correct declensions for non-Icelandic names are not applied.


# How

## Name encoding

The set of Icelandic names is encoded in a single large string. The string contains a trie-encoding that works like so:

* Initialize an empty stack of characters.
* For each character in the string:
    * If `.` is encountered, the current stack represents an Icelandic name.
    * If `<` is encountered, pop the last character from the stack.
    * If any other character is encountered, append it to the stack.

Here's an example of names encoded using this method:

```
ás.t.vald.ur.<<<<r.<<in.<<eig.<<<<björn.
```

This encodes the following names:

```
Ás
Ást
Ástvald
Ástvaldur
Ástvar
Ástvin
Ástveig
Ástbjörn
```

I tried various compression methods such as:

 * Pack the bits of the 5/6 bit characters into bytes (Icelandic characters can be encoded using 6 bits, or 5 if you add a separate character to denote accented characters).
 * Compress long `<<<<` sequences into numbers e.g. `<<<<` becomes `4`.
 * Use uppercase to denote the end of a string e.g. `ás.t.vald.ur.` becomes `áSTvalDuR`.

All of these methods reduced the size of the string. However, each of them made gzip compression less effective and resulted in a net size increase. For that reason we stick with the super-simple encoding.


## Add `setPredicate` to `beygla`

To avoid polluting the interface of `applyCase`, `beygla` exposes a new undocumented `setPredicate` export that can be used to provide a predicate that determines whether or not a name is declined.

`beygla/strict` uses this by providing a predicate and re-exporting `beygla`:

```tsx
import { setPredicate } from "./beygla";

function isIcelandicName(name: string): boolean {
  // ...
}
setPredicate(isIcelandicName);

export * from "./beygla";
```

This guarantenes that the API for `beygla` and `beygla/strict` stays the same.


# Drive-by

## Handle multiple name categories for single entry in BÍN data

There are 3 entries in the BÍN data containing multiple word categories, one of which added since `beygla` was last updated.

Instead of filtering them out, as is currently done, we now treat multiple categories for a single entry as valid.