### PR TITLE
Use plural address cases when the singular case is not available

### DIFF
--- a/lib/addresses.spec.ts
+++ b/lib/addresses.spec.ts
@@ -135,7 +135,10 @@ describe("beygla/addresses", () => {
 
     it("applies cases to addresses that only exist in the plural case", () => {
       const cases = ["nf", "þf", "þgf", "ef"] as const;
-      const names = [["Álfheimar", "Álfheima", "Álfheimum", "Álfheima"]];
+      const names = [
+        ["Álfheimar", "Álfheima", "Álfheimum", "Álfheima"],
+        ["Glaðheimar", "Glaðheima", "Glaðheimum", "Glaðheima"],
+      ];
       for (const group of names) {
         const base = group[0];
         for (const [i, caseStr] of cases.entries()) {

--- a/lib/addresses.spec.ts
+++ b/lib/addresses.spec.ts
@@ -17,6 +17,7 @@ if (testingBuild) {
 }
 
 const knownProblemAddresses = [
+  // Singular
   "Efri-Hreppur",
   "Efri-Núpur",
   "Efsta-Grund",
@@ -77,6 +78,16 @@ const knownProblemAddresses = [
   "Ytri-Hóll",
   "Ytri-Hólmur",
   "Ytri-Ós",
+
+  // Plural
+  "Efsta-Kot",
+  "Garðar",
+  "Kot",
+  "Minni-Akrar",
+  "Minni-Ólafsvellir",
+  "Minni-Reykir",
+  "Minni-Vellir",
+  "Ásar",
 ];
 
 const { applyCase } = beygla;
@@ -120,6 +131,17 @@ describe("beygla/addresses", () => {
     it("strips whitespace", () => {
       const sourceName = "  \n  Rauðalækur  \t63\n";
       expect(applyCase("þf", sourceName)).toEqual("Rauðalæk 63");
+    });
+
+    it("applies cases to addresses that only exist in the plural case", () => {
+      const cases = ["nf", "þf", "þgf", "ef"] as const;
+      const names = [["Álfheimar", "Álfheima", "Álfheimum", "Álfheima"]];
+      for (const group of names) {
+        const base = group[0];
+        for (const [i, caseStr] of cases.entries()) {
+          expect(applyCase(caseStr, base)).toEqual(group[i]);
+        }
+      }
     });
   });
 });

--- a/lib/beygla.spec.ts
+++ b/lib/beygla.spec.ts
@@ -197,7 +197,6 @@ function runTests(beygla: typeof import("./beygla"), strict: boolean) {
           "Frederik",
           "Evan",
           "Lennon",
-          "Artemis",
           "Kaín",
         ];
 

--- a/lib/preprocess/format/case.ts
+++ b/lib/preprocess/format/case.ts
@@ -2,10 +2,16 @@ import { Case } from "../../compress/types";
 
 export function isFirstVariationOfCase(caseString: string): boolean {
   switch (caseString) {
+    // Singular
     case "NFET":
     case "ÞFET":
     case "ÞGFET":
     case "EFET":
+    // Plural
+    case "NFFT":
+    case "ÞFFT":
+    case "ÞGFFT":
+    case "EFFT":
       return true;
   }
   return false;
@@ -14,12 +20,16 @@ export function isFirstVariationOfCase(caseString: string): boolean {
 export function getCase(caseString: string): Case {
   switch (caseString) {
     case "NFET":
+    case "NFFT":
       return Case.Nominative;
     case "ÞFET":
+    case "ÞFFT":
       return Case.Accusative;
     case "ÞGFET":
+    case "ÞGFFT":
       return Case.Dative;
     case "EFET":
+    case "EFFT":
       return Case.Genitive;
     default:
       throw new Error(`Unexpected case '${caseString}'`);
@@ -47,4 +57,8 @@ export function isCasePlural(caseString: string): boolean {
     default:
       throw new Error(`Unexpected case '${caseString}'`);
   }
+}
+
+export function isCaseSingular(caseString: string) {
+  return !isCasePlural(caseString);
 }

--- a/scripts/prepare-list-of-addresses.ts
+++ b/scripts/prepare-list-of-addresses.ts
@@ -3,6 +3,10 @@ import fs from "fs";
 import { writeAndLogSize } from "../lib/preprocess/utils/gzip";
 import assert from "assert";
 
+const addressesToExclude = new Set([
+  "Hermes", // For some reason, this name is present in 'icelandic-addresses.csv'
+]);
+
 type Keys =
   | "FID"
   | "HNITNUM"
@@ -61,6 +65,8 @@ function main() {
     assert(typeof name === "string" && !!name);
 
     if (name.includes(" ")) continue; // No spaces in address names
+
+    if (addressesToExclude.has(name)) continue;
 
     addresses.add(name);
   }


### PR DESCRIPTION
Closes #21

## What

Some addresses, such as Álfheimar, only exist in the plural case:

```
Álfheimar;248582;kk;bær;1;;;;V;Álfheimum;ÞGFFT;1;;;
Álfheimar;248582;kk;bær;1;;;;V;Álfheima;ÞFFT;1;;;
Álfheimar;248582;kk;bær;1;;;;V;Álfheima;EFFT;1;;;
Álfheimar;248582;kk;bær;1;;;;V;Álfheimar;NFFT;1;;;
```

This PR makes beygla use plural declension data for addresses when no data for the singular case exists.

This change is specific to the `beygla/addresses` module and does not apply to the main `beygla` module.
