### PR TITLE
perf: remove subtraction from encoding

### DIFF
--- a/lib/beygla.spec.ts
+++ b/lib/beygla.spec.ts
@@ -169,19 +169,19 @@ function runTests(beygla: typeof import("./beygla"), strict: boolean) {
 
       it("finds correct declension for some unknown names", () => {
         const tests: Array<[name: string, declension: string]> = [
-          ["Sotti", "1;i,a,a,a"],
-          ["Sófía", "1;a,u,u,u"],
-          ["Kórekur", "2;ur,,i,s"],
-          ["Olivia", "1;a,u,u,u"],
-          ["Caritas", "0;,,,ar"],
-          ["Hávarr", "1;r,,i,s"],
-          ["Ermenga", "1;a,u,u,u"],
-          ["Fannþór", "0;,,i,s"],
-          ["Ísbrá", "0;,,,r"],
-          ["Sófús", "0;,,i,ar"],
-          ["Kristólín", "0;,,,ar"],
-          ["Jasper", "0;,,,s"],
-          ["Agok", "0;,,,s"],
+          ["Sotti", "i,a,a,a"],
+          ["Sófía", "a,u,u,u"],
+          ["Kórekur", "ur,,i,s"],
+          ["Olivia", "a,u,u,u"],
+          ["Caritas", ",,,ar"],
+          ["Hávarr", "r,,i,s"],
+          ["Ermenga", "a,u,u,u"],
+          ["Fannþór", ",,i,s"],
+          ["Ísbrá", ",,,r"],
+          ["Sófús", ",,i,ar"],
+          ["Kristólín", ",,,ar"],
+          ["Jasper", ",,,s"],
+          ["Agok", ",,,s"],
         ];
 
         for (const [name, declension] of tests) {

--- a/lib/beygla.ts
+++ b/lib/beygla.ts
@@ -28,23 +28,14 @@ function getCaseIndex(caseStr: Case) {
   return 0; // Fall back to 0 if an invalid case was provided
 }
 
-function parseDeclension(declension: string) {
-  const [subtractString, appendicesString] = declension.split(";");
-
-  const subtraction = Number(subtractString);
-  const appendices = (appendicesString || "").split(",");
-
-  return [subtraction, appendices] as const;
-}
-
 function declineName(name: string, declension: string, caseStr: Case): string {
-  const [subtraction, appendices] = parseDeclension(declension);
+  const appendices = declension.split(",");
+  const subtraction = appendices[0].length;
 
   const caseIndex = getCaseIndex(caseStr);
 
   // Should not happen, but prefer being safe
-  if (!Number.isFinite(subtraction)) return name;
-  if (appendices.length !== 4) return name;
+  if (!Number.isFinite(subtraction) || appendices.length !== 4) return name;
 
   const root = name.substr(0, name.length - subtraction);
   return root + appendices[caseIndex];
@@ -61,9 +52,9 @@ function applyCaseToName(caseStr: Case, name: string) {
     const endsWithSon = namesThatEndWithSon.indexOf(name) !== -1;
     if (!endsWithSon) {
       for (const [ending, declension] of [
-        ["son", "2;on,on,yni,onar"],
-        ["dóttir", "2;ir,ur,ur,ur"],
-        ["bur", "0;,,i,s"],
+        ["son", "on,on,yni,onar"],
+        ["dóttir", "ir,ur,ur,ur"],
+        ["bur", ",,i,s"],
       ]) {
         if (!name.endsWith(ending)) continue;
         name = name.split(ending)[0];
@@ -146,7 +137,7 @@ export function getDeclensionForName(name: string): string | null {
     //
     // The name 'Maya' matches this path, but applying the declension erases the
     // entire name.
-    const [_subtraction, appendices] = parseDeclension(declension);
+    const appendices = declension.split(",");
     if (!name.endsWith(appendices[0])) return null;
   }
 

--- a/lib/compress/declension.ts
+++ b/lib/compress/declension.ts
@@ -18,13 +18,11 @@ export function formatDeclension(names: string[]): string {
     root += char;
   }
 
-  const subtract = name.length - root.length;
-
   function getEnding(name: string) {
     return name.substr(root.length);
   }
 
-  const declension = `${subtract};${names.map(getEnding).join(",")}`;
+  const declension = `${names.map(getEnding).join(",")}`;
 
   if (declension === NO_DECLENSION) return NO_DECLENSION_MARKER;
   return declension;

--- a/lib/read/deserialize.ts
+++ b/lib/read/deserialize.ts
@@ -2,7 +2,6 @@ import { NO_DECLENSION, NO_DECLENSION_MARKER } from "../common/constants";
 import { CompressedTrie } from "../common/types";
 
 const isChar = (c: string) => c === "-" || c.toLowerCase() !== c.toUpperCase();
-const isNumeric = (c: string) => /^[0-9]$/.test(c);
 const validTerminator = (c: string) => ["!", "_"].indexOf(c) !== -1;
 
 type Node = [node: CompressedTrie, done: boolean];
@@ -14,30 +13,17 @@ export function deserializeTrie(str: string): CompressedTrie {
   const next = () => i++;
 
   function deserializeLeaf(): Node {
-    let subtraction = char();
-    next(); // Move beyond number to ';' or '~'
-
     function returnValue(c: string, value: string): Node {
       if (!validTerminator(c)) throw new Error("INV_TER: " + c);
       return [{ value, children: {} }, c === "!"];
     }
 
-    if (subtraction === NO_DECLENSION_MARKER) {
-      const c = char();
+    const firstChar = char();
+
+    if (firstChar === NO_DECLENSION_MARKER) {
       next(); // Move beyond terminator
-      return returnValue(c, NO_DECLENSION);
+      return returnValue(firstChar, NO_DECLENSION);
     }
-
-    // Subtraction may be composed of multiple numbers. Keep searching
-    {
-      let c: string;
-      while (isNumeric((c = char()))) {
-        subtraction += c;
-        next();
-      }
-    }
-
-    next(); // Move to first part
 
     const parts: string[] = [];
 
@@ -55,7 +41,7 @@ export function deserializeTrie(str: string): CompressedTrie {
       next(); // Move beyond terminator or separator
 
       if (i === 3) {
-        return returnValue(c, `${subtraction};${parts.join(",")}`);
+        return returnValue(c, parts.join(","));
       }
 
       // 'c' should be terminator
@@ -96,13 +82,10 @@ export function deserializeTrie(str: string): CompressedTrie {
 
   function deserialize(): Node {
     const c = char();
-    if (c === NO_DECLENSION_MARKER || isNumeric(c)) {
-      return deserializeLeaf();
-    }
     if (c === "{") {
       return deserializeObject();
     }
-    throw new Error("INV_CHAR: " + c);
+    return deserializeLeaf();
   }
 
   return deserialize()[0];


### PR DESCRIPTION
# What

Remove subtraction count from forms encoding:

```
# Before
2;ur,,i,ar

# After
ur,,i,ar
```


# Why

It was pointed out to me by @vthorsteinsson that the forms encoding does not need to contain the subtraction count since it can be inferred from the nominative suffix.

Removing the subtraction count makes the library a bit smaller (0.26 kB, to be exact). Here is the full build output before/after:

```
# Before
beygla.js
        Minified: 12.67 kB
        Gzipped: 4.74 kB
beygla.esm.js
        Minified: 12.6 kB
        Gzipped: 4.72 kB
strict.js
        Minified: 44.14 kB
        Gzipped: 14.84 kB
strict.esm.js
        Minified: 44.05 kB
        Gzipped: 14.82 kB
addresses.js
        Minified: 16.08 kB
        Gzipped: 5.83 kB
addresses.esm.js
        Minified: 16.01 kB
        Gzipped: 5.81 kB

# After
beygla.js
        Minified: 11.19 kB
        Gzipped: 4.48 kB
beygla.esm.js
        Minified: 11.12 kB
        Gzipped: 4.46 kB
strict.js
        Minified: 42.66 kB
        Gzipped: 14.56 kB
strict.esm.js
        Minified: 42.57 kB
        Gzipped: 14.54 kB
addresses.js
        Minified: 14.46 kB
        Gzipped: 5.48 kB
addresses.esm.js
        Minified: 14.39 kB
        Gzipped: 5.46 kB
```
